### PR TITLE
Potential fix for code scanning alert no. 7: Uncontrolled data used in path expression

### DIFF
--- a/server.py
+++ b/server.py
@@ -39,7 +39,12 @@ file_system = {
 
 # --- User Data Persistence ---
 def get_user_data_path(username):
-    return os.path.join("cloud_saves", f"{username}.json")
+    # Prevent path traversal: normalize and check prefix
+    base_dir = os.path.abspath("cloud_saves")
+    requested_path = os.path.normpath(os.path.join(base_dir, f"{username}.json"))
+    if not requested_path.startswith(base_dir + os.sep):
+        raise ValueError("Invalid username/path traversal detected")
+    return requested_path
 
 def save_user_data(username, data):
     if not os.path.exists("cloud_saves"):


### PR DESCRIPTION
Potential fix for [https://github.com/TheMasterCoders/FusionBytes/security/code-scanning/7](https://github.com/TheMasterCoders/FusionBytes/security/code-scanning/7)

To fix the problem, we should ensure that the file path constructed from the user-supplied `username` is always contained within the intended `cloud_saves` directory. This can be achieved by normalizing the path using `os.path.normpath` and then checking that the resulting path starts with the absolute path of the `cloud_saves` directory. If the check fails, the request should be rejected. The best place to implement this is in the `get_user_data_path` function, so that all uses of this function benefit from the fix. We should also consider rejecting usernames that contain path separators or other suspicious characters, but the normalization and prefix check is the most robust solution.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
