### PR TITLE
Potential fix for code scanning alert no. 5: Uncontrolled data used in path expression

### DIFF
--- a/server.py
+++ b/server.py
@@ -1,6 +1,7 @@
 import os
 import json
 from flask import Flask, jsonify, request, render_template, send_from_directory
+from werkzeug.utils import secure_filename
 import time
 import threading
 import logging
@@ -39,7 +40,14 @@ file_system = {
 
 # --- User Data Persistence ---
 def get_user_data_path(username):
-    return os.path.join("cloud_saves", f"{username}.json")
+    safe_username = secure_filename(username)
+    path = os.path.join("cloud_saves", f"{safe_username}.json")
+    # Defense-in-depth: ensure path is within cloud_saves
+    base_dir = os.path.abspath("cloud_saves")
+    full_path = os.path.abspath(path)
+    if not full_path.startswith(base_dir + os.sep):
+        raise ValueError("Invalid username for file path.")
+    return full_path
 
 def save_user_data(username, data):
     if not os.path.exists("cloud_saves"):


### PR DESCRIPTION
Potential fix for [https://github.com/TheMasterCoders/FusionBytes/security/code-scanning/5](https://github.com/TheMasterCoders/FusionBytes/security/code-scanning/5)

To fix this problem, we need to ensure that the `username` value cannot be used to escape the intended `cloud_saves` directory or otherwise manipulate the file path. The best way to do this is to sanitize the `username` input before using it in a file path. One robust approach is to use `werkzeug.utils.secure_filename`, which strips out dangerous characters and path components, ensuring the resulting filename is safe. Additionally, after constructing the path, we can normalize it and check that it still resides within the `cloud_saves` directory as a defense-in-depth measure.

**Steps:**
- Import `secure_filename` from `werkzeug.utils`.
- In `get_user_data_path`, sanitize the `username` using `secure_filename` before constructing the path.
- Optionally, after joining and normalizing the path, check that it starts with the absolute path of the `cloud_saves` directory.

All changes are to be made in `server.py` within the code shown.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
