### PR TITLE
Potential fix for code scanning alert no. 3: Uncontrolled data used in path expression

### DIFF
--- a/server.py
+++ b/server.py
@@ -1,6 +1,7 @@
 import os
 import json
 from flask import Flask, jsonify, request, render_template, send_from_directory
+from werkzeug.utils import secure_filename
 import time
 import threading
 import logging
@@ -39,7 +40,14 @@ file_system = {
 
 # --- User Data Persistence ---
 def get_user_data_path(username):
-    return os.path.join("cloud_saves", f"{username}.json")
+    safe_username = secure_filename(username)
+    path = os.path.join("cloud_saves", f"{safe_username}.json")
+    # Defense-in-depth: ensure path is within cloud_saves
+    fullpath = os.path.abspath(os.path.normpath(path))
+    cloudsaves_dir = os.path.abspath("cloud_saves")
+    if not fullpath.startswith(cloudsaves_dir + os.sep):
+        raise ValueError("Invalid username for file path.")
+    return fullpath
 
 def save_user_data(username, data):
     if not os.path.exists("cloud_saves"):


### PR DESCRIPTION
Potential fix for [https://github.com/TheMasterCoders/FusionBytes/security/code-scanning/3](https://github.com/TheMasterCoders/FusionBytes/security/code-scanning/3)

To fix this issue, we need to ensure that the `username` used in file paths cannot be abused for path traversal or absolute path attacks. The best way to do this is to sanitize the `username` before using it in any file path. In this context, using `werkzeug.utils.secure_filename` is a robust and simple solution, as it strips out dangerous characters and ensures the resulting filename is safe. We should apply this sanitization in the `get_user_data_path` function, so all usages are protected. Additionally, we should ensure that the resulting path is still within the `cloud_saves` directory after joining and normalizing, as a defense-in-depth measure.

**Required changes:**
- Import `secure_filename` from `werkzeug.utils`.
- In `get_user_data_path`, sanitize the `username` using `secure_filename`.
- Optionally, after constructing the path, normalize it and check that it is still within the `cloud_saves` directory.

All changes are within `server.py`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
