### PR TITLE
Potential fix for code scanning alert no. 1: Uncontrolled data used in path expression

### DIFF
--- a/server.py
+++ b/server.py
@@ -1,6 +1,7 @@
 import os
 import json
 from flask import Flask, jsonify, request, render_template, send_from_directory
+from werkzeug.utils import secure_filename
 import time
 import threading
 import logging
@@ -39,7 +40,15 @@ file_system = {
 
 # --- User Data Persistence ---
 def get_user_data_path(username):
-    return os.path.join("cloud_saves", f"{username}.json")
+    # Sanitize the username to prevent path traversal
+    safe_username = secure_filename(username)
+    base_dir = os.path.abspath("cloud_saves")
+    path = os.path.join(base_dir, f"{safe_username}.json")
+    norm_path = os.path.normpath(path)
+    # Ensure the normalized path is within the intended directory
+    if not norm_path.startswith(base_dir):
+        raise Exception("Invalid username/path traversal detected")
+    return norm_path
 
 def save_user_data(username, data):
     if not os.path.exists("cloud_saves"):


### PR DESCRIPTION
Potential fix for [https://github.com/TheMasterCoders/FusionBytes/security/code-scanning/1](https://github.com/TheMasterCoders/FusionBytes/security/code-scanning/1)

To fix the problem, we need to ensure that the constructed file path for user data is safe and cannot be used for path traversal or to access files outside the intended directory. The best way to do this is to sanitize the `username` input before using it in a file path. We can use the `werkzeug.utils.secure_filename` function to strip out dangerous characters and ensure the filename is safe. Additionally, after constructing the path, we should normalize it and check that it resides within the intended `cloud_saves` directory. This can be done by using `os.path.normpath` and verifying that the resulting path starts with the absolute path of the `cloud_saves` directory.

The changes should be made in the `get_user_data_path` function in `server.py` (lines 41-42), and we need to import `secure_filename` from `werkzeug.utils`. The function should sanitize the username, construct the path, normalize it, and check that it is within the intended directory. If the path is invalid, it should raise an exception or return a safe default.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
